### PR TITLE
Add filter to only push current message through to ODE

### DIFF
--- a/Translators/WZDx/main.py
+++ b/Translators/WZDx/main.py
@@ -6,11 +6,19 @@ import os
 from request_wrapper import get_sdw_request, get_rsu_request
 from tim_generator import generate_tim
 from flask import request, Flask
+from datetime import datetime
 
 app = Flask(__name__)
 
 log_level = os.environ.get('LOGGING_LEVEL', 'INFO')
 logging.basicConfig(format='%(levelname)s:%(message)s', level=log_level)
+
+def record_active(feature):
+    startDate = datetime.strptime(feature["properties"]["start_date"], "%Y-%m-%dT%H:%M:%SZ")
+    if (datetime.utcnow().replace(tzinfo=None) - startDate.replace(tzinfo=None)).total_seconds() >= -1800:
+        return True
+    else:
+        return False
 
 def update_sat_region_name(request, tim_body):
     new_tim = copy.deepcopy(tim_body)
@@ -32,9 +40,9 @@ def update_rsu_region_name(request, tim_body):
 
 def translate(wzdx_geojson):
     tims = []
-    duration = os.getenv("DURATION_TIME", 1800)
+    duration = os.getenv("DURATION_TIME", 30)
     # if no RSUs found, drop that one
-    for feature in wzdx_geojson["features"]:
+    for feature in wzdx_geojson:
         tim_body = generate_tim(feature)
         if tim_body is not None:
             for msg in tim_body["dataframes"]:
@@ -122,6 +130,9 @@ def WZDx_tim_translator():
 
     # Scrape the CDOT endpoint to get current list of WZDX features
     geoJSON =  json.loads(requests.get(f'https://{os.getenv("WZDX_ENDPOINT")}/api/v1/wzdx?apiKey={os.getenv("WZDX_API_KEY")}').content.decode('utf-8'))
+
+    # Filter out future records
+    geoJSON = [feature for feature in geoJSON["features"] if record_active(feature) == True]
 
     tim_list = translate(geoJSON)
 

--- a/Translators/WZDx/main.py
+++ b/Translators/WZDx/main.py
@@ -15,7 +15,8 @@ logging.basicConfig(format='%(levelname)s:%(message)s', level=log_level)
 
 def record_active(feature):
     startDate = datetime.strptime(feature["properties"]["start_date"], "%Y-%m-%dT%H:%M:%SZ")
-    if (datetime.utcnow().replace(tzinfo=None) - startDate.replace(tzinfo=None)).total_seconds() >= -1800:
+    endDate = datetime.strptime(feature["properties"]["end_date"], "%Y-%m-%dT%H:%M:%SZ")
+    if (datetime.utcnow().replace(tzinfo=None) - startDate.replace(tzinfo=None)).total_seconds() >= -1800 and datetime.utcnow() < endDate:
         return True
     else:
         return False
@@ -100,7 +101,7 @@ def translateWzdxTIM():
         'Content-Type': 'application/json'
     }
 
-    tims = translate(request.get_json())
+    tims = translate(request.get_json()["features"])
     return (json.dumps(tims), 200, headers)
 
 @app.route('/', methods=['POST'])

--- a/Translators/WZDx/tim_generator.py
+++ b/Translators/WZDx/tim_generator.py
@@ -178,13 +178,21 @@ def vehicle_impact_supported(vehicle_impact):
 def get_first_road_name(feature):
     return feature["properties"]["core_details"]["road_names"][0]
 
+def get_start_date(feature):
+    # if utcnow > start_date, then set time to be utcnow
+    # else if utcnow < start_date, then set time to be start_date
+    if (datetime.utcnow() - datetime.strptime(feature["properties"]["start_date"], "%Y-%m-%dT%H:%M:%SZ")).total_seconds() >= 0:
+        return (datetime.utcnow()).isoformat()[:-3] + "Z"
+    else:
+        return feature["properties"]["start_date"]
+
 
 def get_data_frames(feature):
     coords = copy.deepcopy(feature["geometry"]["coordinates"])
     anchor = get_anchor(feature)
     if anchor is None:
         return None
-    start_date = feature["properties"]["start_date"]
+    start_date = get_start_date(feature)
     duration = get_duration_time_minutes(feature)
     msgId = get_msg_id(anchor)
 

--- a/tests/Translators/WZDx/test_tim_generator.py
+++ b/tests/Translators/WZDx/test_tim_generator.py
@@ -109,8 +109,10 @@ def test_calculateOffsetPath():
 @patch('Translators.WZDx.tim_generator.get_msg_id')
 @patch('Translators.WZDx.tim_generator.vehicle_impact_supported')
 @patch('Translators.WZDx.tim_generator.get_first_road_name')
-def test_getDataFrames(mockRoad, mockSupported, mockMsgId, mockDuration, mockDeepCopy, mockAnchor):
+@patch('Translators.WZDx.tim_generator.get_start_date')
+def test_getDataFrames(mockStart, mockRoad, mockSupported, mockMsgId, mockDuration, mockDeepCopy, mockAnchor):
 
+    mockStart.return_value = "2022-02-13T16:00:00Z"
     mockDeepCopy.return_value = dataframes_data.coords
     mockAnchor.return_value = dataframes_data.anchor
     mockDuration.return_value = 0


### PR DESCRIPTION
This PR does the following:
- Adds a filter after scraping WZDx endpoint to remove future messages
- Updates TIM start time to be utcnow() if message is active
- Updates existing tests to pass with code changes