### PR TITLE
Fix long region names

### DIFF
--- a/Translators/WZDx/main.py
+++ b/Translators/WZDx/main.py
@@ -27,6 +27,8 @@ def update_sat_region_name(request, tim_body):
     region_name = new_tim['dataframes'][0]['regions'][0]['name']
     region_name = region_name.replace(
         'IDENTIFIER', f"SAT_{request['sdw']['recordId']}")
+    if len(region_name) > 63:
+        region_name = region_name[:63]
     new_tim['dataframes'][0]['regions'][0]['name'] = region_name
     return new_tim
 
@@ -36,6 +38,8 @@ def update_rsu_region_name(request, tim_body):
     region_name = new_tim['dataframes'][0]['regions'][0]['name']
     region_name = region_name.replace(
         'IDENTIFIER', f"RSU_{request['rsus'][0]['rsuTarget']}")
+    if len(region_name) > 63:
+        region_name = region_name[:63]
     new_tim['dataframes'][0]['regions'][0]['name'] = region_name
     return new_tim
 

--- a/Translators/WZDx/main.py
+++ b/Translators/WZDx/main.py
@@ -28,7 +28,7 @@ def update_sat_region_name(request, tim_body):
     region_name = region_name.replace(
         'IDENTIFIER', f"SAT_{request['sdw']['recordId']}")
     if len(region_name) > 63:
-        region_name = region_name[:63]
+        region_name = region_name[:60] + '...'
     new_tim['dataframes'][0]['regions'][0]['name'] = region_name
     return new_tim
 
@@ -39,7 +39,7 @@ def update_rsu_region_name(request, tim_body):
     region_name = region_name.replace(
         'IDENTIFIER', f"RSU_{request['rsus'][0]['rsuTarget']}")
     if len(region_name) > 63:
-        region_name = region_name[:63]
+        region_name = region_name[:60] + '...'
     new_tim['dataframes'][0]['regions'][0]['name'] = region_name
     return new_tim
 


### PR DESCRIPTION
Truncates the 'name' field under regions to be no longer than 63 characters. This fixes an error in the AEM where it is unable to encode region names of more than 63 characters.