### PR TITLE
Update SNMP version determination

### DIFF
--- a/Translators/WZDx/request_wrapper.py
+++ b/Translators/WZDx/request_wrapper.py
@@ -133,7 +133,6 @@ def get_rsu_request(feature):
         snmp_info = get_snmp_info(rsu["rsuTarget"])
         snmp_protocol = get_snmp_protocol(rsu["rsuTarget"])
         if snmp_info is not None:
-            print("version_code: ", snmp_protocol[0]["version_code"])
             rsu["snmpProtocol"] = "NTCIP1218" if snmp_protocol[0]["version_code"] == "1218" else "FOURDOT1"
             rsu["rsuUsername"] = snmp_info[0]["username"]
             rsu["rsuPassword"] = snmp_info[0]["password"]

--- a/Translators/WZDx/request_wrapper.py
+++ b/Translators/WZDx/request_wrapper.py
@@ -112,6 +112,14 @@ def get_snmp_info(rsuTarget):
     query = f"SELECT nickname, username, password FROM snmp_credentials WHERE snmp_credential_id = (SELECT snmp_credential_id FROM rsus WHERE ipv4_address = '{rsuTarget}')"
     return query_db(query)
 
+def get_snmp_protocol(rsuTarget):
+    query = (
+        f"SELECT snmp.version_code from public.snmp_versions as snmp "
+        f"JOIN public.rsus as rsu ON rsu.snmp_version_id = snmp.snmp_version_id "
+        f"WHERE rsu.ipv4_address = '{rsuTarget}'"
+    )
+    return query_db(query)
+
 def get_rsu_request(feature):
     rsus = get_rsus_for_message(feature['geometry'])
     if rsus is None:
@@ -123,8 +131,10 @@ def get_rsu_request(feature):
     for rsu in rsus:
     # get snmp protocol, username, password for each rsu
         snmp_info = get_snmp_info(rsu["rsuTarget"])
+        snmp_protocol = get_snmp_protocol(rsu["rsuTarget"])
         if snmp_info is not None:
-            rsu["snmpProtocol"] = "NTCIP1218" if snmp_info[0]["nickname"] == "Yunex BUILD" else "FOURDOT1"
+            print("version_code: ", snmp_protocol[0]["version_code"])
+            rsu["snmpProtocol"] = "NTCIP1218" if snmp_protocol[0]["version_code"] == "1218" else "FOURDOT1"
             rsu["rsuUsername"] = snmp_info[0]["username"]
             rsu["rsuPassword"] = snmp_info[0]["password"]
 

--- a/tests/Translators/WZDx/data/request_wrapper_data.py
+++ b/tests/Translators/WZDx/data/request_wrapper_data.py
@@ -112,7 +112,33 @@ expected_snmp_settings = {
 }
 
 expected_rsu_request = {
-    "rsus": rsu_intersect_result,
+    "rsus": [{
+    "latitude": 0,
+    "longitude": 0,
+    "rsuId": "rsu1",
+    "route": "route1",
+    "milepost": 0,
+    "rsuTarget": "10.10.10.10",
+    "rsuRetries": 3,
+    "rsuTimeout": 5000,
+    "rsuIndex": 2,
+    "rsuUsername": "username",
+    "rsuPassword": "password",
+    "snmpProtocol": "NTCIP1218"
+}, {
+    "latitude": 1,
+    "longitude": 1,
+    "rsuId": "rsu2",
+    "route": "route2",
+    "milepost": 0,
+    "rsuTarget": "10.10.10.11",
+    "rsuRetries": 3,
+    "rsuTimeout": 5000,
+    "rsuIndex": 2,
+    "rsuUsername": "username",
+    "rsuPassword": "password",
+    "snmpProtocol": "NTCIP1218",
+}],
     "snmp": expected_snmp_settings
 }
 
@@ -120,4 +146,8 @@ expected_snmp_info = [{
     "nickname": "nickname",
     "username": "username",
     "password": "password"
+}]
+
+expected_snmp_protocol = [{
+    "version_code": "1218"
 }]

--- a/tests/Translators/WZDx/test_request_wrapper.py
+++ b/tests/Translators/WZDx/test_request_wrapper.py
@@ -97,8 +97,10 @@ def test_get_rsu_request_no_rsus(mock_get_snmp_info, mock_get_rsus_for_message):
 @patch('Translators.WZDx.request_wrapper.get_rsus_for_message')
 @patch('Translators.WZDx.request_wrapper.get_snmp_settings')
 @patch('Translators.WZDx.request_wrapper.get_snmp_info')
-def test_get_rsu_request_rsus(mock_get_snmp_info, mock_get_snmp_settings, mock_get_rsus_for_message):
+@patch('Translators.WZDx.request_wrapper.get_snmp_protocol')
+def test_get_rsu_request_rsus(mock_get_snmp_protocol, mock_get_snmp_info, mock_get_snmp_settings, mock_get_rsus_for_message):
     mock_get_rsus_for_message.return_value = data.rsu_intersect_result
     mock_get_snmp_settings.return_value = data.expected_snmp_settings
     mock_get_snmp_info.return_value = data.expected_snmp_info
+    mock_get_snmp_protocol.return_value = data.expected_snmp_protocol
     assert request_wrapper.get_rsu_request(data.example_feature) == data.expected_rsu_request


### PR DESCRIPTION
Updates request_wrapper.py to determine which version of SNMP an rsu is running by checking the version code instead of just the manufacturer. Previously, this was assigning NTCIP1218 only to Yunex devices. 

Unit tests have been updated to pass with these changes