### PR TITLE
Update Clear Index 

### DIFF
--- a/Translators/WZDx/main.py
+++ b/Translators/WZDx/main.py
@@ -5,7 +5,6 @@ import logging
 import os
 from request_wrapper import get_sdw_request, get_rsu_request
 from tim_generator import generate_tim
-from snmp_operations import clear_index
 from flask import request, Flask
 from datetime import datetime
 
@@ -143,13 +142,6 @@ def WZDx_tim_translator():
     tim_list = translate(geoJSON)
 
     logging.info('Pushing TIMs to ODE...')
-
-    # Clear index for each RSU before pushing to ODE
-    for tim in tim_list:
-        if tim["request"].get("rsus") is not None:
-            rsus = tim["request"].get("rsus")
-            for rsu in rsus:
-                clear_index(rsu)
 
     errNo = 0
     for tim in tim_list:

--- a/Translators/WZDx/request_wrapper.py
+++ b/Translators/WZDx/request_wrapper.py
@@ -1,5 +1,6 @@
 import secrets
 from shapely.geometry import LineString
+from snmp_operations import clear_index
 import rsu_service
 import geospatial_service
 from pgquery import query_db
@@ -136,6 +137,9 @@ def get_rsu_request(feature):
             rsu["snmpProtocol"] = "NTCIP1218" if snmp_protocol[0]["version_code"] == "1218" else "FOURDOT1"
             rsu["rsuUsername"] = snmp_info[0]["username"]
             rsu["rsuPassword"] = snmp_info[0]["password"]
+
+    # remove any RSUs that fail to clear the index
+    rsus = [rsu for rsu in rsus if clear_index(rsu)]
 
     if rsus != []:
         tim_req = {

--- a/Translators/WZDx/snmp_operations.py
+++ b/Translators/WZDx/snmp_operations.py
@@ -1,3 +1,4 @@
+import re
 import requests
 import json
 import os
@@ -19,5 +20,12 @@ def clear_index(rsu):
     
     if response.status_code == 200:
         print(f'Index {rsu["rsuIndex"]} cleared for RSU {rsu["rsuTarget"]}')
+        return True
     else:
-        print(f'Failed to clear index {rsu["rsuIndex"]} for RSU {rsu["rsuTarget"]}: {response.content.decode("utf-8")}')
+        err = response.content.decode("utf-8")
+        if (re.search(r'Invalid index', err) is not None):
+            return False
+        if (re.search(r'Timeout', err) is not None):
+            return False
+        print(f'Failed to clear index {rsu["rsuIndex"]} for RSU {rsu["rsuTarget"]}: {err}')
+        return True

--- a/tests/Translators/WZDx/test_request_wrapper.py
+++ b/tests/Translators/WZDx/test_request_wrapper.py
@@ -98,7 +98,9 @@ def test_get_rsu_request_no_rsus(mock_get_snmp_info, mock_get_rsus_for_message):
 @patch('Translators.WZDx.request_wrapper.get_snmp_settings')
 @patch('Translators.WZDx.request_wrapper.get_snmp_info')
 @patch('Translators.WZDx.request_wrapper.get_snmp_protocol')
-def test_get_rsu_request_rsus(mock_get_snmp_protocol, mock_get_snmp_info, mock_get_snmp_settings, mock_get_rsus_for_message):
+@patch('Translators.WZDx.request_wrapper.clear_index')
+def test_get_rsu_request_rsus(mock_clear_index, mock_get_snmp_protocol, mock_get_snmp_info, mock_get_snmp_settings, mock_get_rsus_for_message):
+    mock_clear_index.return_value = True
     mock_get_rsus_for_message.return_value = data.rsu_intersect_result
     mock_get_snmp_settings.return_value = data.expected_snmp_settings
     mock_get_snmp_info.return_value = data.expected_snmp_info


### PR DESCRIPTION
This update will only attempt to deposit to RSUs that can successfully clear the target index for the message. If the error is an invalid index or timeout error, the translator will not send the TIM to the ODE, otherwise, the TIM will be sent to the ODE. 

Unit tests have been updated to pass with these changes. 