### PR TITLE
Parse additional ITIS codes

### DIFF
--- a/Translators/WZDx/itis_codes.py
+++ b/Translators/WZDx/itis_codes.py
@@ -55,3 +55,16 @@ class ItisCodes(Enum):
     STOP_AT_NEXT_SAFE_PLACE = '7188'
     ONLY_TRAVEL_IF_NECESSARY = '7189'
     FALLING_ROCKS = '1203'
+
+ItisCodeExtraKeywords = {
+    "herd of animals on roadway": "herd of animals on the roadway",
+    "rockfall": "rock fall",
+    "wildfire": "wild fire",
+    "keep to right": "keep right",
+    "keep to left": "keep left",
+    "reduce your speed": "reduce speed",
+    "drive careful": "drive carefully",
+    "stop at next safe place": "stop at the next safe place",
+    "only travel if necessary": "only necessary travel",
+    "falling rocks": "falling rock"
+}

--- a/tests/Translators/WZDx/test_tim_generator.py
+++ b/tests/Translators/WZDx/test_tim_generator.py
@@ -61,11 +61,39 @@ def test_getAnchor(mock_geospacial_service):
 def test_getItisCodes_allLanesClosed():
     feature = {
         'properties': {
-            'vehicle_impact': 'all-lanes-closed'
+            'vehicle_impact': 'all-lanes-closed',
+            'core_details': {
+                'description': ''
+            }
         }
     }
     itisCodes = tim_generator.get_itis_codes(feature)
     assert itisCodes == ['770']  # ItisCodes.CLOSED.value
+
+def test_getItisCodes_typesOfWork():
+    feature = {
+        'properties': {
+            'vehicle_impact': '',
+            'core_details': {
+                'description': 'description'
+            },
+            'types_of_work': [{'type_name': 'roadway-creation', 'is_architectural_change': True}]
+        }
+    }
+    itisCodes = tim_generator.get_itis_codes(feature)
+    assert itisCodes == ['1025']  # ItisCodes.ROAD_CONSTRUCTION.value
+
+def test_getItisCodes_multipleCodes():
+    feature = {
+        'properties': {
+            'vehicle_impact': '',
+            'core_details': {
+                'description': 'Width limit in effect, accident on right portion of road. Keep to right.'
+            }
+        }
+    }
+    itisCodes = tim_generator.get_itis_codes(feature)
+    assert itisCodes == ['513', '2573', '7425']  # ItisCodes.WIDTH_LIMIT.value, ItisCodes.ACCIDENT.value, ItisCodes.KEEP_RIGHT.value
 
 ############################ calculateOffsetPath ############################
 def test_calculateOffsetPath():


### PR DESCRIPTION
This PR adds support for parsing additional ITIS codes in the get_itis_codes method. These changes check the types_of_work field that may be present in a WZDx message and the message description to determine what additional ITIS codes may be applicable. Additionally, unit tests have been added to cover this change and all existing unit tests were verified to pass.