### PR TITLE
Update delivery start/stop & duration calculation

### DIFF
--- a/Translators/WZDx/request_wrapper.py
+++ b/Translators/WZDx/request_wrapper.py
@@ -7,6 +7,7 @@ import geospatial_service
 from pgquery import query_db
 import re
 import os
+from datetime import datetime, timedelta
 
 
 def get_bounding_box(geometry):
@@ -97,6 +98,10 @@ def get_snmp_settings(feature):
 
     Returns:
         snmpSettings (dict): SNMP settings object'''
+    
+    utc_now = datetime.utcnow()
+    delivery_start = utc_now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    delivery_end = (utc_now + timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     return {
         "rsuid": "83",
@@ -104,8 +109,8 @@ def get_snmp_settings(feature):
         "mode": 1,
         "channel": 183,
         "interval": 1000,
-        "deliverystart": feature["properties"]["start_date"],
-        "deliverystop": feature["properties"]["end_date"],
+        "deliverystart": delivery_start,
+        "deliverystop": delivery_end,
         "enable": 1,
         "status": 4
     }

--- a/Translators/WZDx/tim_generator.py
+++ b/Translators/WZDx/tim_generator.py
@@ -1,29 +1,11 @@
 import math
 import copy
+import os
 import secrets
 from datetime import datetime
 import geospatial_service
 from itis_codes import ItisCodes
 from utils import calculate_direction
-import logging
-
-
-def get_duration_time_minutes(feature):
-    '''Get duration in minutes from a GeoJSON feature object with start_date and end_date properties
-
-    Parameters:
-        feature (dict): A GeoJSON feature object. Assumed to have properties 'start_date' and 'end_date'
-
-    Returns:
-        duration (int): Duration in minutes. Note 32000 represents infinity'''
-    # "start_date": "2022-02-13T16:00:00Z",
-    # "end_date": "2022-02-13T16:55:00Z",
-    start_date = datetime.strptime(feature[
-        "properties"]["start_date"], "%Y-%m-%dT%H:%M:%SZ")
-    end_date = datetime.strptime(feature[
-        "properties"]["end_date"], "%Y-%m-%dT%H:%M:%SZ")
-    duration = (end_date - start_date).total_seconds() / 60
-    return int(duration) if duration < 32000 else 32000
 
 # calculate anchor point 15 meters from start of path
 def calculate_anchor(p1, p2):
@@ -218,7 +200,7 @@ def get_data_frames(feature):
     if anchor is None:
         return None
     start_date = get_start_date(feature)
-    duration = get_duration_time_minutes(feature)
+    duration = os.getenv("DURATION_TIME", 30)
     msgId = get_msg_id(anchor)
 
     # In here need to calculate if size of path is greater than 63

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ mock
 functions-framework==3.0.0
 flask==2.0.2
 google-cloud-error-reporting==1.4.1
-pyproj==3.3.1
+pyproj==3.6.1
 requests
-shapely==1.8.5
+shapely==2.0.5
 sqlalchemy
 marshmallow
 werkzeug==2.2.2

--- a/tests/Translators/WZDx/data/dataframes_data.py
+++ b/tests/Translators/WZDx/data/dataframes_data.py
@@ -78,7 +78,7 @@ anchor = {
 
 expected_dataframes = [
     {'startDateTime': '2022-02-13T16:00:00Z',
-     'durationTime': 0,
+     'durationTime': 30,
      'sspTimRights': '1',
      'frameType': 'advisory',
      'msgId': 'some-id',

--- a/tests/Translators/WZDx/data/request_wrapper_data.py
+++ b/tests/Translators/WZDx/data/request_wrapper_data.py
@@ -106,7 +106,7 @@ expected_snmp_settings = {
     "channel": 183,
     "interval": 1000,
     "deliverystart": "2022-11-11T14:00:00Z",
-    "deliverystop": "2022-11-12T00:30:00Z",
+    "deliverystop": "2022-11-11T14:30:00Z",
     "enable": 1,
     "status": 4
 }

--- a/tests/Translators/WZDx/test_request_wrapper.py
+++ b/tests/Translators/WZDx/test_request_wrapper.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import patch
 from Translators.WZDx import request_wrapper
 import tests.Translators.WZDx.data.request_wrapper_data as data
@@ -82,7 +83,9 @@ def test_get_rsus_for_message_found_rsus(mock_rsu_service, mock_geospatial_servi
     assert request_wrapper.get_rsus_for_message(geometry) == data.rsu_intersect_result
 
 ############################ get_snmp_settings ############################
-def test_get_snmp_settings():
+@patch('Translators.WZDx.request_wrapper.datetime')
+def test_get_snmp_settings(mock_datetime):
+    mock_datetime.utcnow.return_value = datetime(2022, 11, 11, 14, 0, 0)
     assert request_wrapper.get_snmp_settings(data.example_feature) == data.expected_snmp_settings
 
 

--- a/tests/Translators/WZDx/test_tim_generator.py
+++ b/tests/Translators/WZDx/test_tim_generator.py
@@ -3,27 +3,6 @@ from Translators.WZDx import tim_generator
 import tests.Translators.WZDx.data.dataframes_data as dataframes_data
 
 
-############################ getDurationTimeMinutes ############################
-def test_getDurationTimeMinutes():
-    feature = {
-        'properties': {
-            'start_date': '2022-02-13T16:00:00Z',
-            'end_date': '2022-02-13T16:55:00Z'
-        }
-    }
-    duration = tim_generator.get_duration_time_minutes(feature)
-    assert duration == 55
-
-def test_getDurationTimeMinutes_withLargeTime():
-    feature = {
-        'properties': {
-            'start_date': '2022-02-13T16:00:00Z',
-            'end_date': '2022-07-13T16:55:00Z'
-        }
-    }
-    duration = tim_generator.get_duration_time_minutes(feature)
-    assert duration == 32000
-
 ############################ getAnchor ############################    
 @patch('Translators.WZDx.tim_generator.geospatial_service')
 def test_getAnchor(mock_geospacial_service):
@@ -106,17 +85,15 @@ def test_calculateOffsetPath():
 # create a pytest for the get_data_frames function
 @patch('Translators.WZDx.tim_generator.get_anchor')
 @patch('Translators.WZDx.tim_generator.copy.deepcopy')
-@patch('Translators.WZDx.tim_generator.get_duration_time_minutes')
 @patch('Translators.WZDx.tim_generator.get_msg_id')
 @patch('Translators.WZDx.tim_generator.vehicle_impact_supported')
 @patch('Translators.WZDx.tim_generator.get_first_road_name')
 @patch('Translators.WZDx.tim_generator.get_start_date')
-def test_getDataFrames(mockStart, mockRoad, mockSupported, mockMsgId, mockDuration, mockDeepCopy, mockAnchor):
+def test_getDataFrames(mockStart, mockRoad, mockSupported, mockMsgId, mockDeepCopy, mockAnchor):
 
     mockStart.return_value = "2022-02-13T16:00:00Z"
     mockDeepCopy.return_value = dataframes_data.coords
     mockAnchor.return_value = dataframes_data.anchor
-    mockDuration.return_value = 0
     mockMsgId.return_value = "some-id"
     mockSupported.return_value = False
     mockRoad.return_value = "some-road"


### PR DESCRIPTION
This PR updates the SNMP delivery start and delivery stop to use the current UTC time instead of the start and end times found on the WZDx message. This also removes the get_duration_time_minutes method and instead uses the DURATION_TIME env variable. All unit tests have been verified to pass using pytest.