### PR TITLE
Update Region 1 Exclusion

### DIFF
--- a/Translators/WZDx/request_wrapper.py
+++ b/Translators/WZDx/request_wrapper.py
@@ -146,9 +146,6 @@ def get_rsu_request(feature):
     rsus = get_rsus_for_message(feature['geometry'])
     if rsus is None:
         return None
-    
-    # remove any region 1 RSUs from the list for the time being
-    rsus = [rsu for rsu in rsus if re.match(r"^10\.11\.81", rsu["rsuTarget"]) == None]
 
     # remove any RSUs that are not currently online (based on last 5 pings)
     rsus = [rsu for rsu in rsus if check_rsu_online(rsu)]

--- a/Translators/WZDx/rsu_service.py
+++ b/Translators/WZDx/rsu_service.py
@@ -5,7 +5,7 @@ import shapely.wkt
 rsu_index_dict = {} # Used to store the current index of each RSU
 
 def get_rsus_intersecting_geometry(geometry):
-    query = f"SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE rsu_id not in (SELECT rsu_id FROM rsu_organization as ro JOIN organizations as o on ro.organization_id = o.organization_id WHERE ro.organization_id IN (SELECT organization_id FROM organizations WHERE name = 'Region 1')) AND ST_Intersects('{str(geometry)}', geography)"
+    query = f"SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE rsu_id not in (SELECT rsu_id FROM rsu_organization as ro JOIN organizations as o on ro.organization_id = o.organization_id WHERE o.name = 'Region 1') AND ST_Intersects('{str(geometry)}', geography)"
     try:
         result = pgquery.query_db(query)
     except Exception as e:

--- a/Translators/WZDx/rsu_service.py
+++ b/Translators/WZDx/rsu_service.py
@@ -5,7 +5,7 @@ import shapely.wkt
 rsu_index_dict = {} # Used to store the current index of each RSU
 
 def get_rsus_intersecting_geometry(geometry):
-    query = f"SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE ST_Intersects('{str(geometry)}', geography)"
+    query = f"SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE primary_route != 'Region 1' AND ST_Intersects('{str(geometry)}', geography)"
     try:
         result = pgquery.query_db(query)
     except Exception as e:

--- a/Translators/WZDx/rsu_service.py
+++ b/Translators/WZDx/rsu_service.py
@@ -5,7 +5,7 @@ import shapely.wkt
 rsu_index_dict = {} # Used to store the current index of each RSU
 
 def get_rsus_intersecting_geometry(geometry):
-    query = f"SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE primary_route != 'Region 1' AND rsu_id in (SELECT rsu_id FROM rsu_organization AS ro JOIN organizations AS o on ro.organization_id = o.organization_id WHERE ro.organization_id IN (SELECT organization_id FROM organizations WHERE name != 'Region 1')) AND ST_Intersects('{str(geometry)}', geography)"
+    query = f"SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE rsu_id not in (SELECT rsu_id FROM rsu_organization as ro JOIN organizations as o on ro.organization_id = o.organization_id WHERE ro.organization_id IN (SELECT organization_id FROM organizations WHERE name = 'Region 1')) AND ST_Intersects('{str(geometry)}', geography)"
     try:
         result = pgquery.query_db(query)
     except Exception as e:

--- a/Translators/WZDx/rsu_service.py
+++ b/Translators/WZDx/rsu_service.py
@@ -5,7 +5,7 @@ import shapely.wkt
 rsu_index_dict = {} # Used to store the current index of each RSU
 
 def get_rsus_intersecting_geometry(geometry):
-    query = f"SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE primary_route != 'Region 1' AND ST_Intersects('{str(geometry)}', geography)"
+    query = f"SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE primary_route != 'Region 1' AND rsu_id in (SELECT rsu_id FROM rsu_organization AS ro JOIN organizations AS o on ro.organization_id = o.organization_id WHERE ro.organization_id IN (SELECT organization_id FROM organizations WHERE name != 'Region 1')) AND ST_Intersects('{str(geometry)}', geography)"
     try:
         result = pgquery.query_db(query)
     except Exception as e:

--- a/tests/Translators/WZDx/test_rsu_service.py
+++ b/tests/Translators/WZDx/test_rsu_service.py
@@ -15,7 +15,7 @@ def set_rsu_index_dict(request):
 def test_get_rsus_intersecting_geometry_no_data(mock_pgquery):
     mock_pgquery.query_db.return_value = {}
     expected_rsu_data = None
-    expected_query = "SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE ST_Intersects('TEST', geography)"
+    expected_query = "SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE primary_route != 'Region 1' AND ST_Intersects('TEST', geography)"
     actual_result = rsu_service.get_rsus_intersecting_geometry('TEST')
     mock_pgquery.query_db.assert_called_with(expected_query)
 

--- a/tests/Translators/WZDx/test_rsu_service.py
+++ b/tests/Translators/WZDx/test_rsu_service.py
@@ -15,7 +15,7 @@ def set_rsu_index_dict(request):
 def test_get_rsus_intersecting_geometry_no_data(mock_pgquery):
     mock_pgquery.query_db.return_value = {}
     expected_rsu_data = None
-    expected_query = "SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE primary_route != 'Region 1' AND rsu_id in (SELECT rsu_id FROM rsu_organization AS ro JOIN organizations AS o on ro.organization_id = o.organization_id WHERE ro.organization_id IN (SELECT organization_id FROM organizations WHERE name != 'Region 1')) AND ST_Intersects('TEST', geography)"
+    expected_query = "SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE rsu_id not in (SELECT rsu_id FROM rsu_organization as ro JOIN organizations as o on ro.organization_id = o.organization_id WHERE ro.organization_id IN (SELECT organization_id FROM organizations WHERE name = 'Region 1')) AND ST_Intersects('TEST', geography)"
     actual_result = rsu_service.get_rsus_intersecting_geometry('TEST')
     mock_pgquery.query_db.assert_called_with(expected_query)
 

--- a/tests/Translators/WZDx/test_rsu_service.py
+++ b/tests/Translators/WZDx/test_rsu_service.py
@@ -15,7 +15,7 @@ def set_rsu_index_dict(request):
 def test_get_rsus_intersecting_geometry_no_data(mock_pgquery):
     mock_pgquery.query_db.return_value = {}
     expected_rsu_data = None
-    expected_query = "SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE primary_route != 'Region 1' AND ST_Intersects('TEST', geography)"
+    expected_query = "SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE primary_route != 'Region 1' AND rsu_id in (SELECT rsu_id FROM rsu_organization AS ro JOIN organizations AS o on ro.organization_id = o.organization_id WHERE ro.organization_id IN (SELECT organization_id FROM organizations WHERE name != 'Region 1')) AND ST_Intersects('TEST', geography)"
     actual_result = rsu_service.get_rsus_intersecting_geometry('TEST')
     mock_pgquery.query_db.assert_called_with(expected_query)
 

--- a/tests/Translators/WZDx/test_rsu_service.py
+++ b/tests/Translators/WZDx/test_rsu_service.py
@@ -15,7 +15,7 @@ def set_rsu_index_dict(request):
 def test_get_rsus_intersecting_geometry_no_data(mock_pgquery):
     mock_pgquery.query_db.return_value = {}
     expected_rsu_data = None
-    expected_query = "SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE rsu_id not in (SELECT rsu_id FROM rsu_organization as ro JOIN organizations as o on ro.organization_id = o.organization_id WHERE ro.organization_id IN (SELECT organization_id FROM organizations WHERE name = 'Region 1')) AND ST_Intersects('TEST', geography)"
+    expected_query = "SELECT rsu_id, primary_route, milepost, ipv4_address,  ST_AsText(geography) point FROM rsus WHERE rsu_id not in (SELECT rsu_id FROM rsu_organization as ro JOIN organizations as o on ro.organization_id = o.organization_id WHERE o.name = 'Region 1') AND ST_Intersects('TEST', geography)"
     actual_result = rsu_service.get_rsus_intersecting_geometry('TEST')
     mock_pgquery.query_db.assert_called_with(expected_query)
 


### PR DESCRIPTION
This PR Updates the get_rsus_intersecting_geometry method to exclude any RSUs with Region 1 as their primary region.