### PR TITLE
Azure Pipeline Update

### DIFF
--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -15,7 +15,7 @@ pool:
 steps:
   - task: CopyFiles@2
     inputs:
-      SourceFolder: 'services'
+      SourceFolder: 'Translators/WZDx'
       Contents: '**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 

--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -13,19 +13,15 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - task: ArchiveFiles@2
-    name: zip_wzdxTranslator
+  - task: CopyFiles@2
     inputs:
-      rootFolderOrFile: "Translators/WZDx"
-      includeRootFolder: false
-      archiveType: "zip"
-      archiveFile: "$(Build.ArtifactStagingDirectory)/WZDx.zip"
-      replaceExistingArchive: true
-      verbose: true
+      SourceFolder: 'services'
+      Contents: '**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   # Publish the artifacts directory for consumption in publish pipeline
   - task: PublishBuildArtifacts@1
     inputs:
-      PathtoPublish: "$(Build.ArtifactStagingDirectory)"
-      ArtifactName: "zipped_functions"
-      publishLocation: "Container"
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: 'tim-tools'
+      publishLocation: 'Container'


### PR DESCRIPTION
Updates the Azure pipeline instructions to copy over the whole WZDx directory instead of zipping it to make it easier to perform a Docker build from a release pipeline. This is also how the jpo-cvmanager has its Azure pipelines configured.