### PR TITLE
Azure Pipeline Fix

### DIFF
--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -29,6 +29,6 @@ steps:
   # Publish the artifacts directory for consumption in publish pipeline
   - task: PublishBuildArtifacts@1
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/Translators/WZDx/'
       ArtifactName: 'tim-tools'
       publishLocation: 'Container'

--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -7,6 +7,7 @@ trigger:
   paths:
     include:
     - "Translators/WZDx/*"
+    - "Translators/Shared/*"
 
 
 pool:

--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -17,6 +17,12 @@ steps:
   - task: CopyFiles@2
     inputs:
       SourceFolder: 'Translators/WZDx'
+      Contents: 'Dockerfile'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: 'Translators/WZDx'
       Contents: '**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)/Translators/WZDx'
 
@@ -29,6 +35,6 @@ steps:
   # Publish the artifacts directory for consumption in publish pipeline
   - task: PublishBuildArtifacts@1
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)/Translators/WZDx/'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
       ArtifactName: 'tim-tools'
       publishLocation: 'Container'

--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -15,7 +15,13 @@ pool:
 steps:
   - task: CopyFiles@2
     inputs:
-      SourceFolder: 'Translators'
+      SourceFolder: 'Translators/WZDx'
+      Contents: '**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: 'Translators/Shared'
       Contents: '**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 

--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -7,7 +7,6 @@ trigger:
   paths:
     include:
     - "Translators/WZDx/*"
-    - "Translators/Shared/*"
 
 
 pool:

--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -3,7 +3,7 @@
 trigger:
   branches:
     include:
-    - Bug/Azure-Pipeline-Fix
+    - master
   paths:
     include:
     - "Translators/WZDx/*"

--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -3,10 +3,11 @@
 trigger:
   branches:
     include:
-    - master
+    - Bug/Azure-Pipeline-Fix
   paths:
     include:
     - "Translators/WZDx/*"
+    - "Translators/Shared/*"
 
 
 pool:
@@ -15,7 +16,7 @@ pool:
 steps:
   - task: CopyFiles@2
     inputs:
-      SourceFolder: 'Translators/WZDx'
+      SourceFolder: 'Translators'
       Contents: '**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 

--- a/Translators/WZDx/azure-pipelines.yml
+++ b/Translators/WZDx/azure-pipelines.yml
@@ -18,13 +18,13 @@ steps:
     inputs:
       SourceFolder: 'Translators/WZDx'
       Contents: '**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/Translators/WZDx'
 
   - task: CopyFiles@2
     inputs:
       SourceFolder: 'Translators/Shared'
       Contents: '**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/Translators/Shared'
 
   # Publish the artifacts directory for consumption in publish pipeline
   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
When #24 was merged the Azure pipeline responsible for deployment broke. These changes update the pipeline to use the new shared package in the build. This was verified to work by inspecting the pipeline output on Azure DevOps.